### PR TITLE
[ops] Fix Grover's mirror on qc.Grover()

### DIFF
--- a/beta/src/qcengine_scriptpanel.js
+++ b/beta/src/qcengine_scriptpanel.js
@@ -615,7 +615,7 @@ function QScriptInterface(qReg)
             condition_mask = 0;
         this.hadamard(target_mask);
         this.x(target_mask);
-        this.cz(0, target_mask|condition_mask);
+        this.cz(~0, target_mask|condition_mask);
         this.x(target_mask);
         this.hadamard(target_mask);
     }

--- a/src/qcengine_scriptpanel.js
+++ b/src/qcengine_scriptpanel.js
@@ -615,7 +615,7 @@ function QScriptInterface(qReg)
             condition_mask = 0;
         this.hadamard(target_mask);
         this.x(target_mask);
-        this.cz(0, target_mask|condition_mask);
+        this.cz(~0, target_mask|condition_mask);
         this.x(target_mask);
         this.hadamard(target_mask);
     }


### PR DESCRIPTION
When using Grover's mirror as in `qcengine_scriptpanel.js` like in the O'Reilly simulator vis with ```qc.Grovers()```, the controlled phase gate is incorrect. Noticed first on the [O'Reilly simulator visualization](https://oreilly-qc.github.io/), here is the before:

![image](https://github.com/machinelevel/QCEngine/assets/43344745/7f62c4ac-8430-40f1-8d8f-b2aab981f461)

After:

![image](https://github.com/machinelevel/QCEngine/assets/43344745/16a1ede4-efb7-4255-8066-494249d6a281)

This was because the mask for cz was `0` and not `~0`.